### PR TITLE
Org id checking in datasources proxy

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -253,7 +253,7 @@ func (proxy *DataSourceProxy) validateRequest() error {
 		}
 	}
 	
-	if proxy.ctx.SignedInUser.OrgId != proxy.ctx.Req.Request.Header.Get("X-Grafana-Org-Id") {
+	if String(proxy.ctx.SignedInUser.OrgId) != proxy.ctx.Req.Request.Header.Get("X-Grafana-Org-Id") {
 		return errors.New("Org-id in header not match with logged in user")
 	}
 

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -252,6 +252,10 @@ func (proxy *DataSourceProxy) validateRequest() error {
 			return errors.New("Posts not allowed on proxied Elasticsearch datasource except on /_msearch")
 		}
 	}
+	
+	if proxy.ctx.SignedInUser.OrgId != proxy.ctx.Req.Request.Header.Get("X-Grafana-Org-Id") {
+		return errors.New("Org-id in header not match with logged in user")
+	}
 
 	// found route if there are any
 	if len(proxy.plugin.Routes) > 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [`CONTRIBUTING.md`](https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md) guide.
2. Ensure you have added or ran the appropriate tests for your PR.
3. If it's a new feature or config option it will need a docs update. Docs are under the docs folder in repo root.
4. If the PR is unfinished, mark it as a draft PR.
5. Rebase your PR if it gets out of sync with master
-->
In order to use [Cortex](https://github.com/cortexproject/cortex), a multi-tenant Prometheus, as a datasource, we need to pass a OrgId in header to Cortex.

In current, Grafana passes a header 'X-Grafana-Org-Id' while querying datasource.
However, Grafana do not check if the user is belong to the org.
When a user change the header in client side, who can access other tenant's data in Cortex.

This PR is to check the X-Grafana-Org-Id coming from client matches the OrgId of logged-in user in datasources proxy.
 
